### PR TITLE
[Feature] Add orb rooms to radar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ Dates in this file are in [Holocene Calendar] because it is amazing, logical, an
 
 ## [Unreleased]
 
+### Added
+  - Orb radar can now show Orb Room both in NG and NG+ (Checkbox at the bottom of the radar).
+
+### Changed
+- Searching algorithm now work in a spiral pattern around the player.
+
 ### Fixed
   - Orb radar can now find the player whe cessated.
 
 ## [v0.3.0] 12025-03-06
 
 ### BREAKING
- - If you used the previous version to discover that `Jan 25 2025` (or newer) build of Noita is broken, you need to go into "Address Maps" (under the "+" button if it isn't there) and delete the mapping for that version - then restart to let it re-discover the mapping. You may notice that the value for `entity-tag-manager` is nonsensical - you could actually just update it to `0x1206fac` (for the jan 25 build) instead.
+  - If you used the previous version to discover that `Jan 25 2025` (or newer) build of Noita is broken, you need to go into "Address Maps" (under the "+" button if it isn't there) and delete the mapping for that version - then restart to let it re-discover the mapping. You may notice that the value for `entity-tag-manager` is nonsensical - you could actually just update it to `0x1206fac` (for the jan 25 build) instead.
 
 ### Added
   - Orb radar can now also look for sampo positions

--- a/justfile
+++ b/justfile
@@ -8,6 +8,12 @@ check:
     cargo doc --no-deps --all-features
     cargo test --all-features
 
+build target:
+    nix build . ".#{{target}}"
+
+build-all:
+    nix build . ".#windows" ".#linux" ".#deb"
+
 release version: check
     #!/usr/bin/env bash
     set -euo pipefail

--- a/noita-engine-reader/src/noita/rng.rs
+++ b/noita-engine-reader/src/noita/rng.rs
@@ -56,6 +56,13 @@ impl NoitaRng {
         }
         rng
     }
+
+    /// Skip N steps
+    pub fn skip(&mut self, n: usize) {
+        for _ in 0..n {
+            self.next();
+        }
+    }
 }
 
 // wrapping_sub soup

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,22 @@ of another on top of fullscreen Noita some informations:
 - [ ] Coords
 - [ ] Arbitrary entity component informations?
 
+## Development
+
+### Building from sources
+
+Building require [Nix](https://nixos.org/download/), with the 3 targets `.#windows`,
+`.#linux` and `.#deb`:
+
+- `nix build . .#{{target}}`
+
+As a helper a `justfile` provide the following commands:
+
+- `just check` will check for formatting and clippy errors
+- `just build (windows|linux|deb)` to build a specific artefact
+- `just build-all` to build all three artefacts
+
+
 ## License
 It's MIT, please have a copy of the LICENSE file in your derivatives so that my
 name is there lol

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,21 @@ There are plans for more stuff to come, some low handing fruits like hitless
 checker, less low ones like modless streamer wands, I want to do a git backup
 manager, a mod update manager, etc etc
 
+##### Orb Radar
+There is much room for improvements, being functionality or readability:
+
+- [x] Display current world orb rooms in NG & NG+
+- [ ] Filter orbs that are already taken
+- [ ] Better accessibility features for the radar
+
+##### Ingame overlay
+For peoples like @Larandar that don't have a second screen, inject in one way
+of another on top of fullscreen Noita some informations:
+
+- [ ] Orb radar
+- [ ] Coords
+- [ ] Arbitrary entity component informations?
+
 ## License
 It's MIT, please have a copy of the LICENSE file in your derivatives so that my
 name is there lol

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -8,17 +8,40 @@ use tracing::Instrument;
 use crate::util::{Promise, persist};
 use noita_engine_reader::{Seed, rng::NoitaRng};
 
+pub const CHUNK_SIZE: i32 = 512;
+
+#[derive(Debug, Clone, Copy)]
+pub enum OrbSource {
+    Room,
+    Chest,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Orb {
+    #[allow(unused)]
+    pub id: u32,
+    pub pos: Pos2,
+    pub source: OrbSource,
+    pub corrupted: bool,
+}
+
+impl Orb {}
+
 #[derive(Debug, SmartDefault)]
 pub struct OrbSearcher {
-    #[default(1024)]
-    chunk_size: u32,
-    #[default([10, 3])]
+    #[default([16, 9])]
     search_range: [i32; 2],
-    pub look_for_sampo_instead: bool,
-    searched_chunks: HashSet<(i32, i32)>,
-    known_orbs: Vec<Pos2>,
     #[default(Promise::Taken)]
-    search_task: Promise<Vec<(i32, i32)>>,
+    search_task: Promise<Vec<Orb>>,
+
+    // Which PW the rooms are listed
+    #[default(Option::None)]
+    current_rooms_world: Option<i32>,
+    known_rooms: Vec<Orb>,
+
+    searched_chunks: HashSet<(i32, i32)>,
+    known_orbs: Vec<Orb>,
+    pub look_for_sampo_instead: bool,
 }
 
 persist!(OrbSearcher {
@@ -26,16 +49,16 @@ persist!(OrbSearcher {
 });
 
 impl OrbSearcher {
-    pub fn known_orbs(&self) -> &[Pos2] {
+    pub fn known_orbs(&self) -> &[Orb] {
         &self.known_orbs
+    }
+
+    pub fn known_rooms(&self) -> &[Orb] {
+        &self.known_rooms
     }
 
     pub fn searched_chunks(&self) -> usize {
         self.searched_chunks.len()
-    }
-
-    pub fn chunk_size(&self) -> u32 {
-        self.chunk_size
     }
 
     pub fn reset(&mut self) {
@@ -49,9 +72,9 @@ impl OrbSearcher {
     }
 
     fn next_chunk(&mut self, pos: Pos2) -> Option<(i32, i32)> {
-        let xc = pos.x as i32 / self.chunk_size as i32;
-        let yc = pos.y as i32 / self.chunk_size as i32;
-        //meh
+        let xc = pos.x as i32 / CHUNK_SIZE;
+        let yc = pos.y as i32 / CHUNK_SIZE;
+        // TODO: spiral marching
         for x in xc - self.search_range[0]..=xc + self.search_range[0] {
             for y in yc - self.search_range[1]..=yc + self.search_range[1] {
                 if self.searched_chunks.insert((x, y)) {
@@ -63,47 +86,81 @@ impl OrbSearcher {
     }
 
     pub fn poll_search(&mut self, ctx: &Context, seed: Seed, pos: Pos2) {
-        if self.search_task.is_taken() {
-            if let Some((x, y)) = self.next_chunk(pos) {
-                let size = self.chunk_size;
-                let x = x * size as i32;
-                let y = y * size as i32;
-                let ctx = ctx.clone();
-                let sampo = self.look_for_sampo_instead;
-                self.search_task = Promise::spawn(
-                    async move {
-                        let orbs = find_orbs(seed.sum(), x, y, size, size, sampo);
-                        ctx.request_repaint();
-                        orbs
-                    }
-                    .instrument(tracing::trace_span!("search", %seed, x, y, size)),
-                );
-            }
-        } else if let Some(orbs) = self.search_task.poll_take() {
-            self.known_orbs
-                .extend(orbs.into_iter().map(|(x, y)| pos2(x as f32, y as f32)));
+        // First update the orb rooms of the current PW if necessary
+        if self.known_rooms.is_empty()
+            || self.current_rooms_world.unwrap_or(0) != parallel_world(seed.ng_count, &pos)
+        {
+            self.known_rooms = list_orb_rooms(
+                seed.world_seed,
+                seed.ng_count,
+                parallel_world(seed.ng_count, &pos),
+            );
+            self.current_rooms_world = Some(parallel_world(seed.ng_count, &pos));
+        }
+
+        if self.is_searching()
+            && let Some(orbs) = self.search_task.poll_take()
+        {
+            self.known_orbs.extend(orbs);
             return self.poll_search(ctx, seed, pos);
         }
-        self.known_orbs.sort_unstable_by_key(|orb| {
-            let dir = *orb - pos;
-            dir.length_sq() as i32
-        });
+
+        // Since the search grid is not the same size as the Noita tiles, we only search on
+        // even chunks.
+        if let Some((chunk_x, chunk_y)) = self.next_chunk(pos)
+            && chunk_x % 2 == 0
+            && chunk_y % 2 == 0
+        {
+            let (x, y) = (chunk_x * CHUNK_SIZE, chunk_y * CHUNK_SIZE);
+            let ctx = ctx.clone();
+            let sampo = self.look_for_sampo_instead;
+            let parallel_world = parallel_world(seed.ng_count, &pos);
+            self.search_task = Promise::spawn(
+                async move {
+                    // Look for chests in the chunk matching the search parameters (orb/sampo)
+                    let orbs: Vec<Orb> = find_chest_orbs(seed.sum(), x, y, sampo)
+                        .into_iter()
+                        .map(|(x, y)| Orb {
+                            id: (11
+                                + match parallel_world {
+                                    0 => 0,
+                                    ..0 => 128,
+                                    1.. => 256,
+                                }),
+                            pos: pos2(x as f32, y as f32),
+                            source: OrbSource::Chest,
+                            corrupted: false,
+                        })
+                        .collect();
+
+                    ctx.request_repaint();
+                    orbs
+                }
+                .instrument(tracing::trace_span!("search", %seed, x, y)),
+            );
+        }
     }
 }
 
-fn find_orbs(
-    world_seed: u32,
-    x: i32,
-    y: i32,
-    x_size: u32,
-    y_size: u32,
-    sampo: bool,
-) -> Vec<(i32, i32)> {
-    (0..x_size * y_size)
+/// Compute the parallel_world of the current position depending on if we are in NG+ or not.
+fn parallel_world(ng_count: u32, pos: &Pos2) -> i32 {
+    if ng_count == 0 {
+        (pos.x / CHUNK_SIZE as f32 - 35.0) as i32 / 70
+    } else {
+        (pos.x / CHUNK_SIZE as f32 - 32.0) as i32 / 64
+    }
+}
+
+/// Find all chests producing a Greater Chest Orb or Sampo in a 1024x1024 square
+///
+/// This actually search in a 2x2 chunks square, therefore should be called only on even tiles
+/// if no duplicates are wanted.
+fn find_chest_orbs(world_seed: u32, x: i32, y: i32, sampo: bool) -> Vec<(i32, i32)> {
+    (0..CHUNK_SIZE * CHUNK_SIZE * 4)
         .into_par_iter()
         .filter_map(|i| {
-            let xi = x + (i % x_size) as i32;
-            let yi = y + (i / x_size) as i32;
+            let xi = x + (i % (CHUNK_SIZE * 2));
+            let yi = y + (i / (CHUNK_SIZE * 2));
 
             let mut rng = NoitaRng::from_pos(world_seed, xi as f64, yi as f64);
 
@@ -114,6 +171,191 @@ fn find_orbs(
                 return Some((xi, yi));
             }
             None
+        })
+        .collect()
+}
+
+/// In the main NG world the rooms are fixed.
+const KNOWN_ORB_ROOMS: &[(u32, (i32, i32))] = &[
+    (0, (1, -3)),   // Altar => Sea of Lava
+    (1, (19, -3)),  // Pyramid => Earthquake
+    (2, (-20, 5)),  // Frozen Vault => Tentacles
+    (3, (6, 3)),    // Lava Lake => Nuke
+    (4, (19, 5)),   // Sandcaves => Necromancy
+    (5, (-9, 7)),   // Magical Temple => Holy Bomb
+    (6, (-8, 19)),  // Luki Lair => Spiral Shot
+    (7, (8, 1)),    // Lava Bridge => Thundercloud
+    (8, (-1, 31)),  // Hell => Fireworks
+    (9, (-18, 28)), // Snowy Chasm => Summon Deercoy
+    (10, (20, 31)), // Wizard's Den => Cement
+];
+
+/// Find the orb rooms for the current world_seed, ng_count, parallel_world.
+fn list_orb_rooms(world_seed: u32, ng_count: u32, parallel_world: i32) -> Vec<Orb> {
+    // First check for known orbs for NG
+    let rooms = if ng_count == 0 {
+        KNOWN_ORB_ROOMS
+            .iter()
+            .filter(|(id, _)| *id != 3 || parallel_world == 0) // Lava Lake orb doesn't spawn in PW
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        let mut rooms: Vec<(u32, (i32, i32))> = Vec::new();
+
+        // This function is lifted from kaliuresis/noa (noita-orb-atlas)
+        // Source: https://github.com/kaliuresis/noa > orbs.js#L163
+        let mut rng = NoitaRng::from_pos(world_seed + ng_count, 4573.0, 4621.0);
+
+        // Shorthand to jump the RNG state
+        fn pain_cave(rng: &mut NoitaRng, length: i32) {
+            for i in 1..=length {
+                #[allow(clippy::needless_if)]
+                if i > 4 {
+                    rng.skip(1);
+                }
+
+                if i > 3 {
+                    rng.skip(1);
+                }
+
+                if i > 6 {
+                    rng.skip(4);
+                }
+            }
+        }
+
+        fn paint_biome_area_split(
+            rng: &mut NoitaRng,
+            x: i32,
+            _y: i32,
+            w: i32,
+            _h: i32,
+            buffer: i32,
+        ) {
+            let extra_width = rng.in_range(0, buffer);
+            let x = x - extra_width;
+            let w = w + extra_width + rng.in_range(0, buffer);
+
+            rng.skip(1);
+            for _ in x..x + w {
+                rng.skip(1);
+            }
+        }
+
+        // NG+3,6,... biomes
+        if ng_count % 3 == 0 {
+            rng.skip(12);
+        }
+
+        // Roll to swap biomes
+        rng.skip(6);
+
+        // Biomes suffs
+        // NOTE: Compared to the JS code a lot of stuffs are omitted as they have no side effects
+        for _ in 0..4 {
+            if rng.in_range(0, 100) < 65 {
+                let length = rng.in_range(4, 50);
+                pain_cave(&mut rng, length);
+            }
+        }
+        for _ in 0..4 {
+            if rng.in_range(0, 100) < 65 {
+                rng.skip(1);
+                let length = rng.in_range(5, 50);
+                pain_cave(&mut rng, length);
+            }
+        }
+
+        rng.skip(6);
+
+        paint_biome_area_split(&mut rng, 28, 20, 7, 6, 3);
+        paint_biome_area_split(&mut rng, 28, 27, 7, 4, 4);
+        paint_biome_area_split(&mut rng, 28, 29, 7, 5, 4);
+
+        rng.skip(2);
+
+        if ng_count % 5 == 0 {
+            rng.skip(6);
+        }
+
+        // NOTE: The magic number are from the original JS code.
+        // All generated numbers are offset by (32, 14) chunks in the code, and then later edited.
+        // Therefore here the math is pre-computed and it match the online map ranges.
+
+        // WARNING: I'm really not sure about the IDs in NG+, the JS code was mixing them and there
+        // was 2 different mixing commented...
+
+        // Altar => Sea of Lava
+        rooms.push((0, KNOWN_ORB_ROOMS[1].1)); // Altar in NG+ has ID 1?
+        // Pyramid => Earthquake
+        rooms.push((1, KNOWN_ORB_ROOMS[0].1)); // Pyramd in NG+ has ID 0?
+
+        // Frozen Vault => Tentacles
+        // > x = Random( 0, 5 ) + 10; y = Random( 0, 2 ) + 18;
+        rooms.push((2, (rng.in_range(0, 5) - 22, rng.in_range(0, 2) + 4)));
+
+        // Sandcaves => Necromancy
+        // > x = Random( 0, 5 ) + 49; y = Random( 0, 3 ) + 17;
+        rooms.push((4, (rng.in_range(0, 5) + 17, rng.in_range(0, 3) + 3)));
+
+        // Hell => Fireworks
+        // > x = Random( 0, 9 ) + 27, y = Random( 0, 2 ) + 44
+        // > if( ng == 3 || ng >= 25 ) { y = 47 }
+        let mut hell_orb = (8, (rng.in_range(0, 9) - 5, rng.in_range(0, 2) + 30));
+        if ng_count == 3 || ng_count >= 25 {
+            hell_orb.1.1 = 33
+        }
+        rooms.push(hell_orb);
+
+        // Snowy Chasm => Summon Deercoy
+        // > x = Random( 0, 6 ) + 12; y = Random( 0, 3 ) + 40;
+        rooms.push((9, (rng.in_range(0, 6) - 20, rng.in_range(0, 3) + 26)));
+
+        // Wizard's Den => Cement
+        // > x = Random( 0, 4 ) + 51; y = Random( 0, 5 ) + 41;
+        rooms.push((10, (rng.in_range(0, 4) + 19, rng.in_range(0, 5) + 27)));
+
+        // Lava Lake => Nuke
+        // > x = Random( 0, 5 ) + 58; y = Random( 0, 5 ) + 34;
+        rooms.push((3, (rng.in_range(0, 5) + 26, rng.in_range(0, 5) + 20)));
+
+        // Magical Temple => Holy Bomb
+        // > x = Random( 0, 9 ) + 40; y = Random( 0, 11 ) + 21;
+        rooms.push((5, (rng.in_range(0, 9) + 8, rng.in_range(0, 11) + 7)));
+
+        // Luki Lair => Spiral Shot
+        // > x = Random( 0, 7 ) + 17; y = Random( 0, 8 ) + 21;
+        rooms.push((6, (rng.in_range(0, 7) - 15, rng.in_range(0, 8) + 7)));
+
+        // Lake Orb => Thundercloud
+        // > x = Random( 0, 7 ) + 1; y = Random( 0, 9 ) + 24;
+        rooms.push((7, (rng.in_range(0, 7) - 31, rng.in_range(0, 9) + 10)));
+
+        rooms
+    };
+
+    rooms
+        .iter()
+        .map(|(id, (x, y))| {
+            (
+                // ID of PW orbs are different
+                (id + match parallel_world {
+                    0 => 0,
+                    ..0 => 128,
+                    1.. => 256,
+                }),
+                // The offset of X chunks to the room generation
+                (x + parallel_world * if ng_count == 0 { 70 } else { 64 }, y),
+            )
+        })
+        .map(|(id, (x, y))| Orb {
+            id,
+            pos: pos2(
+                (x as f32 + 0.5) * CHUNK_SIZE as f32,
+                (*y as f32 + 0.75) * CHUNK_SIZE as f32,
+            ), // FIXME: Known orbs are not all orb rooms, therefore some are offset
+            source: OrbSource::Room,
+            corrupted: parallel_world != 0,
         })
         .collect()
 }

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -228,138 +228,7 @@ fn list_orb_rooms(world_seed: u32, ng_count: u32, parallel_world: i32) -> Vec<Or
             .cloned()
             .collect::<Vec<_>>()
     } else {
-        let mut rooms: Vec<(u32, (i32, i32))> = Vec::new();
-
-        // This function is lifted from kaliuresis/noa (noita-orb-atlas)
-        // Source: https://github.com/kaliuresis/noa > orbs.js#L163
-        let mut rng = NoitaRng::from_pos(world_seed + ng_count, 4573.0, 4621.0);
-
-        // Shorthand to jump the RNG state
-        fn pain_cave(rng: &mut NoitaRng, length: i32) {
-            for i in 1..=length {
-                #[allow(clippy::needless_if)]
-                if i > 4 {
-                    rng.skip(1);
-                }
-
-                if i > 3 {
-                    rng.skip(1);
-                }
-
-                if i > 6 {
-                    rng.skip(4);
-                }
-            }
-        }
-
-        fn paint_biome_area_split(
-            rng: &mut NoitaRng,
-            x: i32,
-            _y: i32,
-            w: i32,
-            _h: i32,
-            buffer: i32,
-        ) {
-            let extra_width = rng.in_range(0, buffer);
-            let x = x - extra_width;
-            let w = w + extra_width + rng.in_range(0, buffer);
-
-            rng.skip(1);
-            for _ in x..x + w {
-                rng.skip(1);
-            }
-        }
-
-        // NG+3,6,... biomes
-        if ng_count % 3 == 0 {
-            rng.skip(12);
-        }
-
-        // Roll to swap biomes
-        rng.skip(6);
-
-        // Biomes suffs
-        // NOTE: Compared to the JS code a lot of stuffs are omitted as they have no side effects
-        for _ in 0..4 {
-            if rng.in_range(0, 100) < 65 {
-                let length = rng.in_range(4, 50);
-                pain_cave(&mut rng, length);
-            }
-        }
-        for _ in 0..4 {
-            if rng.in_range(0, 100) < 65 {
-                rng.skip(1);
-                let length = rng.in_range(5, 50);
-                pain_cave(&mut rng, length);
-            }
-        }
-
-        rng.skip(6);
-
-        paint_biome_area_split(&mut rng, 28, 20, 7, 6, 3);
-        paint_biome_area_split(&mut rng, 28, 27, 7, 4, 4);
-        paint_biome_area_split(&mut rng, 28, 29, 7, 5, 4);
-
-        rng.skip(2);
-
-        if ng_count % 5 == 0 {
-            rng.skip(6);
-        }
-
-        // NOTE: The magic number are from the original JS code.
-        // All generated numbers are offset by (32, 14) chunks in the code, and then later edited.
-        // Therefore here the math is pre-computed and it match the online map ranges.
-
-        // WARNING: I'm really not sure about the IDs in NG+, the JS code was mixing them and there
-        // was 2 different mixing commented...
-
-        // Altar => Sea of Lava
-        rooms.push((0, KNOWN_ORB_ROOMS[1].1)); // Altar in NG+ has ID 1?
-        // Pyramid => Earthquake
-        rooms.push((1, KNOWN_ORB_ROOMS[0].1)); // Pyramd in NG+ has ID 0?
-
-        // Frozen Vault => Tentacles
-        // > x = Random( 0, 5 ) + 10; y = Random( 0, 2 ) + 18;
-        rooms.push((2, (rng.in_range(0, 5) - 22, rng.in_range(0, 2) + 4)));
-
-        // Sandcaves => Necromancy
-        // > x = Random( 0, 5 ) + 49; y = Random( 0, 3 ) + 17;
-        rooms.push((4, (rng.in_range(0, 5) + 17, rng.in_range(0, 3) + 3)));
-
-        // Hell => Fireworks
-        // > x = Random( 0, 9 ) + 27, y = Random( 0, 2 ) + 44
-        // > if( ng == 3 || ng >= 25 ) { y = 47 }
-        let mut hell_orb = (8, (rng.in_range(0, 9) - 5, rng.in_range(0, 2) + 30));
-        if ng_count == 3 || ng_count >= 25 {
-            hell_orb.1.1 = 33
-        }
-        rooms.push(hell_orb);
-
-        // Snowy Chasm => Summon Deercoy
-        // > x = Random( 0, 6 ) + 12; y = Random( 0, 3 ) + 40;
-        rooms.push((9, (rng.in_range(0, 6) - 20, rng.in_range(0, 3) + 26)));
-
-        // Wizard's Den => Cement
-        // > x = Random( 0, 4 ) + 51; y = Random( 0, 5 ) + 41;
-        rooms.push((10, (rng.in_range(0, 4) + 19, rng.in_range(0, 5) + 27)));
-
-        // Lava Lake => Nuke
-        // > x = Random( 0, 5 ) + 58; y = Random( 0, 5 ) + 34;
-        rooms.push((3, (rng.in_range(0, 5) + 26, rng.in_range(0, 5) + 20)));
-
-        // Magical Temple => Holy Bomb
-        // > x = Random( 0, 9 ) + 40; y = Random( 0, 11 ) + 21;
-        rooms.push((5, (rng.in_range(0, 9) + 8, rng.in_range(0, 11) + 7)));
-
-        // Luki Lair => Spiral Shot
-        // > x = Random( 0, 7 ) + 17; y = Random( 0, 8 ) + 21;
-        rooms.push((6, (rng.in_range(0, 7) - 15, rng.in_range(0, 8) + 7)));
-
-        // Lake Orb => Thundercloud
-        // > x = Random( 0, 7 ) + 1; y = Random( 0, 9 ) + 24;
-        rooms.push((7, (rng.in_range(0, 7) - 31, rng.in_range(0, 9) + 10)));
-
-        rooms
+        list_orb_rooms_ng_plus(world_seed, ng_count)
     };
 
     rooms
@@ -386,4 +255,133 @@ fn list_orb_rooms(world_seed: u32, ng_count: u32, parallel_world: i32) -> Vec<Or
             corrupted: parallel_world != 0,
         })
         .collect()
+}
+
+/// Find the orb rooms for the current world_seed, ng_count, parallel_world.
+fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32))> {
+    let mut rooms: Vec<(u32, (i32, i32))> = Vec::new();
+
+    // This function is lifted from kaliuresis/noa (noita-orb-atlas)
+    // Source: https://github.com/kaliuresis/noa > orbs.js#L163
+    let mut rng = NoitaRng::from_pos(world_seed + ng_count, 4573.0, 4621.0);
+
+    // Shorthand to jump the RNG state
+    fn pain_cave(rng: &mut NoitaRng, length: i32) {
+        for i in 1..=length {
+            #[allow(clippy::needless_if)]
+            if i > 4 {
+                rng.skip(1);
+            }
+
+            if i > 3 {
+                rng.skip(1);
+            }
+
+            if i > 6 {
+                rng.skip(4);
+            }
+        }
+    }
+
+    fn paint_biome_area_split(rng: &mut NoitaRng, x: i32, _y: i32, w: i32, _h: i32, buffer: i32) {
+        let extra_width = rng.in_range(0, buffer);
+        let x = x - extra_width;
+        let w = w + extra_width + rng.in_range(0, buffer);
+
+        rng.skip(1);
+        for _ in x..x + w {
+            rng.skip(1);
+        }
+    }
+
+    // NG+3,6,... biomes
+    if ng_count % 3 == 0 {
+        rng.skip(12);
+    }
+
+    // Roll to swap biomes
+    rng.skip(6);
+
+    // Biomes suffs
+    // NOTE: Compared to the JS code a lot of stuffs are omitted as they have no side effects
+    for _ in 0..4 {
+        if rng.in_range(0, 100) < 65 {
+            let length = rng.in_range(4, 50);
+            pain_cave(&mut rng, length);
+        }
+    }
+    for _ in 0..4 {
+        if rng.in_range(0, 100) < 65 {
+            rng.skip(1);
+            let length = rng.in_range(5, 50);
+            pain_cave(&mut rng, length);
+        }
+    }
+
+    rng.skip(6);
+
+    paint_biome_area_split(&mut rng, 28, 20, 7, 6, 3);
+    paint_biome_area_split(&mut rng, 28, 27, 7, 4, 4);
+    paint_biome_area_split(&mut rng, 28, 29, 7, 5, 4);
+
+    rng.skip(2);
+
+    if ng_count % 5 == 0 {
+        rng.skip(6);
+    }
+
+    // NOTE: The magic number are from the original JS code.
+    // All generated numbers are offset by (32, 14) chunks in the code, and then later edited.
+    // Therefore here the math is pre-computed and it match the online map ranges.
+
+    // WARNING: I'm really not sure about the IDs in NG+, the JS code was mixing them and there
+    // was 2 different mixing commented...
+
+    // Altar => Sea of Lava
+    rooms.push((0, KNOWN_ORB_ROOMS[1].1)); // Altar in NG+ has ID 1?
+    // Pyramid => Earthquake
+    rooms.push((1, KNOWN_ORB_ROOMS[0].1)); // Pyramd in NG+ has ID 0?
+
+    // Frozen Vault => Tentacles
+    // > x = Random( 0, 5 ) + 10; y = Random( 0, 2 ) + 18;
+    rooms.push((2, (rng.in_range(0, 5) - 22, rng.in_range(0, 2) + 4)));
+
+    // Sandcaves => Necromancy
+    // > x = Random( 0, 5 ) + 49; y = Random( 0, 3 ) + 17;
+    rooms.push((4, (rng.in_range(0, 5) + 17, rng.in_range(0, 3) + 3)));
+
+    // Hell => Fireworks
+    // > x = Random( 0, 9 ) + 27, y = Random( 0, 2 ) + 44
+    // > if( ng == 3 || ng >= 25 ) { y = 47 }
+    let mut hell_orb = (8, (rng.in_range(0, 9) - 5, rng.in_range(0, 2) + 30));
+    if ng_count == 3 || ng_count >= 25 {
+        hell_orb.1.1 = 33
+    }
+    rooms.push(hell_orb);
+
+    // Snowy Chasm => Summon Deercoy
+    // > x = Random( 0, 6 ) + 12; y = Random( 0, 3 ) + 40;
+    rooms.push((9, (rng.in_range(0, 6) - 20, rng.in_range(0, 3) + 26)));
+
+    // Wizard's Den => Cement
+    // > x = Random( 0, 4 ) + 51; y = Random( 0, 5 ) + 41;
+    rooms.push((10, (rng.in_range(0, 4) + 19, rng.in_range(0, 5) + 27)));
+
+    // Lava Lake => Nuke
+    // > x = Random( 0, 5 ) + 58; y = Random( 0, 5 ) + 34;
+    rooms.push((3, (rng.in_range(0, 5) + 26, rng.in_range(0, 5) + 20)));
+
+    // Magical Temple => Holy Bomb
+    // > x = Random( 0, 9 ) + 40; y = Random( 0, 11 ) + 21;
+    rooms.push((5, (rng.in_range(0, 9) + 8, rng.in_range(0, 11) + 7)));
+
+    // Luki Lair => Spiral Shot
+    // > x = Random( 0, 7 ) + 17; y = Random( 0, 8 ) + 21;
+    rooms.push((6, (rng.in_range(0, 7) - 15, rng.in_range(0, 8) + 7)));
+
+    // Lake Orb => Thundercloud
+    // > x = Random( 0, 7 ) + 1; y = Random( 0, 9 ) + 24;
+    rooms.push((7, (rng.in_range(0, 7) - 31, rng.in_range(0, 9) + 10)));
+
+    rooms
 }

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -22,6 +22,7 @@ pub struct Orb {
     pub id: u32,
     pub pos: Pos2,
     pub source: OrbSource,
+    #[allow(unused)]
     pub corrupted: bool,
 }
 

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -172,10 +172,11 @@ impl OrbSearcher {
 /// Compute the parallel_world of the current position depending on if we are in NG+ or not.
 fn parallel_world(ng_count: u32, pos: &Pos2) -> i32 {
     if ng_count == 0 {
-        (pos.x / CHUNK_SIZE as f32 - 35.0) as i32 / 70
+        pos.x / CHUNK_SIZE as f32 / 70.0
     } else {
-        (pos.x / CHUNK_SIZE as f32 - 32.0) as i32 / 64
+        pos.x / CHUNK_SIZE as f32 / 64.0
     }
+    .round() as i32
 }
 
 /// Find all chests producing a Greater Chest Orb or Sampo in the chunk given

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -276,15 +276,9 @@ fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32
         }
     }
 
-    fn paint_biome_area_split(rng: &mut NoitaRng, x: i32, _y: i32, w: i32, _h: i32, buffer: i32) {
-        let extra_width = rng.in_range(0, buffer);
-        let x = x - extra_width;
-        let w = w + extra_width + rng.in_range(0, buffer);
-
-        rng.skip(1);
-        for _ in x..x + w {
-            rng.skip(1);
-        }
+    fn paint_biome_area_split(rng: &mut NoitaRng, width: usize, buffer: i32) {
+        let extra_width = rng.in_range(0, buffer) + rng.in_range(0, buffer) + 1;
+        rng.skip(width + extra_width as usize);
     }
 
     // NG+3,6,... biomes
@@ -313,9 +307,9 @@ fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32
 
     rng.skip(6);
 
-    paint_biome_area_split(&mut rng, 28, 20, 7, 6, 3);
-    paint_biome_area_split(&mut rng, 28, 27, 7, 4, 4);
-    paint_biome_area_split(&mut rng, 28, 29, 7, 5, 4);
+    paint_biome_area_split(&mut rng, 7, 3);
+    paint_biome_area_split(&mut rng, 7, 4);
+    paint_biome_area_split(&mut rng, 7, 4);
 
     rng.skip(2);
 

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -133,12 +133,7 @@ impl OrbSearcher {
             return self.poll_search(ctx, seed, pos);
         }
 
-        // Since the search grid is not the same size as the Noita tiles, we only search on
-        // even chunks.
-        if let Some((chunk_x, chunk_y)) = self.next_chunk(pos)
-            && chunk_x % 2 == 0
-            && chunk_y % 2 == 0
-        {
+        if let Some((chunk_x, chunk_y)) = self.next_chunk(pos) {
             let (x, y) = (chunk_x * CHUNK_SIZE, chunk_y * CHUNK_SIZE);
             let ctx = ctx.clone();
             let sampo = self.look_for_sampo_instead;
@@ -179,16 +174,13 @@ fn parallel_world(ng_count: u32, pos: &Pos2) -> i32 {
     }
 }
 
-/// Find all chests producing a Greater Chest Orb or Sampo in a 1024x1024 square
-///
-/// This actually search in a 2x2 chunks square, therefore should be called only on even tiles
-/// if no duplicates are wanted.
+/// Find all chests producing a Greater Chest Orb or Sampo in the chunk given
 fn find_chest_orbs(world_seed: u32, x: i32, y: i32, sampo: bool) -> Vec<(i32, i32)> {
-    (0..CHUNK_SIZE * CHUNK_SIZE * 4)
+    (0..CHUNK_SIZE * CHUNK_SIZE)
         .into_par_iter()
         .filter_map(|i| {
-            let xi = x + (i % (CHUNK_SIZE * 2));
-            let yi = y + (i / (CHUNK_SIZE * 2));
+            let xi = x + (i % CHUNK_SIZE);
+            let yi = y + (i / CHUNK_SIZE);
 
             let mut rng = NoitaRng::from_pos(world_seed, xi as f64, yi as f64);
 

--- a/src/tools/orb_radar.rs
+++ b/src/tools/orb_radar.rs
@@ -167,7 +167,7 @@ impl OrbRadar {
             for (i, orb) in displayed_orbs.iter().enumerate() {
                 let dir = orb.pos - pos;
                 let pos = rect.center() + dir;
-                let orb_color = self.orb_color(ui, orb);
+                let orb_color = self.orb_color(ui, orb, state);
 
                 if rect.contains(pos) {
                     let color = if i == 0 {
@@ -269,7 +269,7 @@ impl OrbRadar {
             painter.arrow(
                 circle_pos - arrow / 2.0,
                 arrow,
-                Stroke::new(stroke.width, self.orb_color(ui, first_orb)),
+                Stroke::new(stroke.width, self.orb_color(ui, first_orb, state)),
             );
 
             painter.text(
@@ -277,21 +277,18 @@ impl OrbRadar {
                 Align2::LEFT_CENTER,
                 format!("{dist_to_first:.1} px"),
                 text_font,
-                self.orb_color(ui, first_orb),
+                self.orb_color(ui, first_orb, state),
             );
         });
     }
 
-    fn orb_color(&self, ui: &mut Ui, orb: &Orb) -> Color32 {
+    fn orb_color(&self, ui: &Ui, orb: &Orb, state: &AppState) -> Color32 {
+        if !self.show_rooms {
+            return ui.style().visuals.text_color();
+        }
         match orb.source {
-            OrbSource::Room => {
-                if !orb.corrupted {
-                    ui.style().visuals.hyperlink_color
-                } else {
-                    ui.style().visuals.error_fg_color
-                }
-            }
-            OrbSource::Chest => ui.style().visuals.warn_fg_color,
+            OrbSource::Room => state.settings.color_orb_rooms,
+            OrbSource::Chest => state.settings.color_orb_chests,
         }
     }
 }

--- a/src/tools/orb_radar.rs
+++ b/src/tools/orb_radar.rs
@@ -15,6 +15,7 @@ use super::{Result, Tool};
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct OrbRadar {
     realtime: bool,
+    show_rooms: bool,
     orb_searcher: OrbSearcher,
     #[serde(skip)]
     prev_seed: Option<Seed>,
@@ -38,6 +39,7 @@ impl OrbRadar {
         ui.with_layout(Layout::bottom_up(Align::Min), |ui| {
             ui.horizontal(|ui| {
                 ui.checkbox(&mut self.realtime, "Realtime");
+                ui.checkbox(&mut self.show_rooms, "Show orb rooms");
 
                 if ui
                     .checkbox(
@@ -134,14 +136,18 @@ impl OrbRadar {
 
             self.orb_searcher.poll_search(ui.ctx(), seed, pos);
 
-            let mut displayed_orbs: Vec<Orb> = self
-                .orb_searcher
-                .known_rooms()
-                .iter()
-                .chain(self.orb_searcher.known_orbs())
-                // TODO: Filter already picked orbs using the orb id
-                .cloned()
-                .collect();
+            let mut displayed_orbs: Vec<Orb> = if self.show_rooms {
+                self.orb_searcher
+                    .known_orbs()
+                    .iter()
+                    .chain(self.orb_searcher.known_rooms())
+                    .cloned()
+                    .collect()
+            } else {
+                self.orb_searcher.known_orbs().to_vec()
+            };
+
+            // TODO: Filter already picked orbs using the orb id
 
             displayed_orbs.sort_by_key(|orb| {
                 let dir = orb.pos - pos;

--- a/src/tools/settings.rs
+++ b/src/tools/settings.rs
@@ -1,6 +1,6 @@
 use eframe::egui::{
-    self, Checkbox, CollapsingHeader, DragValue, FontId, Grid, Label, RichText, ScrollArea,
-    TextStyle, Ui,
+    self, Checkbox, CollapsingHeader, Color32, DragValue, FontId, Grid, Label, RichText,
+    ScrollArea, TextStyle, Ui,
 };
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
@@ -23,6 +23,11 @@ pub struct SettingsData {
     pub notify_when_outdated: bool,
     #[default(true)]
     pub check_export_name: bool,
+
+    #[default(Color32::GOLD)]
+    pub color_orb_chests: Color32,
+    #[default(Color32::BLUE)]
+    pub color_orb_rooms: Color32,
 
     #[serde(skip)]
     pub newest_version: Option<String>,
@@ -71,6 +76,8 @@ impl Settings {
         ui.separator();
 
         ScrollArea::vertical().show(ui, |ui| {
+            ui.heading("Settings");
+            ui.end_row();
             ui.label("Note: You can permanently scale the UI with Ctrl+- and Ctrl+=");
 
             ui.horizontal(|ui| {
@@ -80,7 +87,10 @@ impl Settings {
 
             ui.separator();
 
-            Grid::new("settings").show(ui, |ui| {
+            Grid::new("general_settings").show(ui, |ui| {
+                ui.heading("General Settings");
+                ui.end_row();
+
                 ui.label("Background updates interval")
                     .on_hover_text("How often the background updates run (used by live stats and noita process auto-detection)");
                 ui.add(
@@ -112,6 +122,24 @@ impl Settings {
                     .on_hover_text("When detecting noita, check that the executable export name is 'wizard_physics.exe'");
                 ui.end_row();
             });
+
+            ui.separator();
+
+            Grid::new("radar_settings").show(ui, |ui| {
+                ui.heading("Radar Settings");
+                ui.end_row();
+
+                ui.label("Greater Chest Orbs color:")
+                    .on_hover_text("Only apply if 'Show orb rooms' is enabled");
+                ui.color_edit_button_srgba(&mut s.color_orb_chests);
+                ui.end_row();
+
+                ui.label("Orb rooms color:");
+                ui.color_edit_button_srgba(&mut s.color_orb_rooms);
+                ui.end_row();
+            });
+
+            ui.separator();
 
             CollapsingHeader::new("egui").show(ui, |ui| {
                 let prev_options = ui.ctx().options(|o| o.clone());


### PR DESCRIPTION
As discussed on Discord, this adds trace toward the orb rooms in the current world of the user:
<img width="1920" height="1200" alt="Screenshot_14-juil _00-05-59_852" src="https://github.com/user-attachments/assets/bca39f08-e771-4499-bbfa-da92018ecb38" />

It differentiates between corrupted and normal orbs via colour at the moment, and works for NG+ orbs:
<img width="1920" height="1200" alt="Screenshot_14-juil _00-01-41_27987" src="https://github.com/user-attachments/assets/93834f18-f5fa-4f1c-8a96-57164db509e2" />
<img width="1920" height="1200" alt="Screenshot_13-juil _23-59-53_1774" src="https://github.com/user-attachments/assets/25cdb7e6-28ed-4be3-9246-7acd936a5ce2" />

Problems in this PR:
- **NO TESTING ON WINDOWS** I can't get nix to compile the Windows binary

Upgrade to be done in a later PR IMO:
- [ ] Filter rooms using the player list of taken orbs ID (including the searched chest orbs?)
- [x] Give the chest orbs the correct ID
- [x] Add settings for the three colours used
- [ ] Improve the UI because I acknowledge that this adds a lot of clutter
    - [ ] Emojis for differentiation in the side list (Chest/Blue Dot/Red Dot?)
    - [ ] Should we put the texts more toward the screen's edges? Let's make it more readable.
    - [ ] Maybe fade the strokes more than the text now that they are coloured?
