### PR TITLE
fix(radar): not resetting rooms when going to NG+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ Dates in this file are in [Holocene Calendar] because it is amazing, logical, an
 ## [Unreleased]
 
 ### Added
-  - Orb radar can now show Orb Room both in NG and NG+ (Checkbox at the bottom of the radar).
+  - Orb radar can now show Orb Rooms in both NG and NG+ (new checkbox at the bottom of the radar). @Larandar
+  - Orb radar now filter collected Orbs (i.e. current PW Greater Chest Orbs, or Orb Rooms). @Larandar
 
 ### Changed
-- Searching algorithm now work in a spiral pattern around the player.
+  - Searching algorithm now processes chunks in a spiral pattern around the player. @Larandar
+  - Searching algorithm now works on noita chunks instead of custom internal 1024x1024 chunks to avoid confusion. @Larandar
 
 ### Fixed
   - Orb radar can now find the player whe cessated.

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -71,6 +71,7 @@ impl OrbSearcher {
     }
 
     pub fn reset(&mut self) {
+        self.known_rooms.clear();
         self.known_orbs.clear();
         self.searched_chunks.clear();
         self.search_task = Promise::Taken;
@@ -261,7 +262,6 @@ fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32
     // Shorthand to jump the RNG state
     fn pain_cave(rng: &mut NoitaRng, length: i32) {
         for i in 1..=length {
-            #[allow(clippy::needless_if)]
             if i > 4 {
                 rng.skip(1);
             }

--- a/src/orb_searcher.rs
+++ b/src/orb_searcher.rs
@@ -10,7 +10,7 @@ use noita_engine_reader::{Seed, rng::NoitaRng};
 
 pub const CHUNK_SIZE: i32 = 512;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum OrbSource {
     Room,
     Chest,
@@ -19,7 +19,7 @@ pub enum OrbSource {
 #[derive(Debug, Clone, Copy)]
 pub struct Orb {
     #[allow(unused)]
-    pub id: u32,
+    pub id: i32,
     pub pos: Pos2,
     pub source: OrbSource,
     #[allow(unused)]
@@ -27,7 +27,7 @@ pub struct Orb {
 }
 
 impl Orb {
-    pub fn parallel_world_id(id: u32, parallel_world: i32) -> u32 {
+    pub fn parallel_world_id(id: i32, parallel_world: i32) -> i32 {
         id + match parallel_world.cmp(&0) {
             Ordering::Equal => 0,
             Ordering::Less => 128,
@@ -202,7 +202,7 @@ fn find_chest_orbs(world_seed: u32, x: i32, y: i32, sampo: bool) -> Vec<(i32, i3
 }
 
 /// In the main NG world the rooms are fixed.
-const KNOWN_ORB_ROOMS: &[(u32, (i32, i32))] = &[
+const KNOWN_ORB_ROOMS: &[(i32, (i32, i32))] = &[
     (0, (1, -3)),   // Altar => Sea of Lava
     (1, (19, -3)),  // Pyramid => Earthquake
     (2, (-20, 5)),  // Frozen Vault => Tentacles
@@ -252,8 +252,8 @@ fn list_orb_rooms(world_seed: u32, ng_count: u32, parallel_world: i32) -> Vec<Or
 }
 
 /// Find the orb rooms for the current world_seed, ng_count, parallel_world.
-fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32))> {
-    let mut rooms: Vec<(u32, (i32, i32))> = Vec::new();
+fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(i32, (i32, i32))> {
+    let mut rooms: Vec<(i32, (i32, i32))> = Vec::new();
 
     // This function is lifted from kaliuresis/noa (noita-orb-atlas)
     // Source: https://github.com/kaliuresis/noa > orbs.js#L163
@@ -325,9 +325,9 @@ fn list_orb_rooms_ng_plus(world_seed: u32, ng_count: u32) -> Vec<(u32, (i32, i32
     // was 2 different mixing commented...
 
     // Altar => Sea of Lava
-    rooms.push((0, KNOWN_ORB_ROOMS[1].1)); // Altar in NG+ has ID 1?
+    rooms.push(KNOWN_ORB_ROOMS[0]);
     // Pyramid => Earthquake
-    rooms.push((1, KNOWN_ORB_ROOMS[0].1)); // Pyramd in NG+ has ID 0?
+    rooms.push(KNOWN_ORB_ROOMS[1]);
 
     // Frozen Vault => Tentacles
     // > x = Random( 0, 5 ) + 10; y = Random( 0, 2 ) + 18;


### PR DESCRIPTION
While implementing the collected rooms filtering, I encountered a bug where I didn't reset `OrbSearcher::known_rooms` on changing seed, which happens when going from NG to NG+. 

The first commit is the fix, I will remove the second commit tomorrow and do another PR for it once I do an NG+28 run as a playtest of the fix+feature.